### PR TITLE
Checked slides on projector

### DIFF
--- a/chunks/montecarlo1.ipynb
+++ b/chunks/montecarlo1.ipynb
@@ -19,7 +19,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -132,8 +132,11 @@
    "source": [
     "## Random number generation\n",
     "Useful terms to know:\n",
+    "\n",
     "* Random: predictable only in the sense of following a PDF\n",
+    "\n",
     "* Pseudorandom: not random, but \"unpredictable enough\" for practical purposes. Various computer algorithms produce pseudorandom sequences that approximate the uniform distribution on [0,1).\n",
+    "\n",
     "* Quasirandom: sequence that doesn't even pretend to be random, but does converge to a target PDF *more quickly* than a random or pseudorandom process would"
    ]
   },
@@ -162,7 +165,7 @@
     }
    },
    "source": [
-    "### Inverse tranfsorm\n",
+    "### Inverse transform\n",
     "\n",
     "Recall the definition of the CDF (and it's inverse, $F^{-1}$, the quantile function),\n",
     "\n",
@@ -185,6 +188,7 @@
    },
    "source": [
     "### Example: exponential distribution\n",
+    "\n",
     "This distribution has $p(x)=\\lambda e^{-\\lambda x}$ and $F(x)=1-e^{-\\lambda x}$ for $x\\geq0$.\n",
     "\n",
     "The quantile function is, therefore, $F^{-1}(P) = -\\ln(1-P)/\\lambda$.\n",
@@ -203,7 +207,7 @@
     "lam = 1.0\n",
     "u = np.random.rand(10000)\n",
     "x = -np.log(1-u)/lam\n",
-    "plt.rcParams['figure.figsize'] = (10.0,7.0)\n",
+    "plt.rcParams['figure.figsize'] = (15.0,8.0)\n",
     "# plots a histogram of these x's and the exponential PDF\n",
     "inv_trans_demo(x, lam)"
    ]
@@ -242,7 +246,7 @@
     "\n",
     "<table>\n",
     "    <tr>\n",
-    "        <td><img src=\"../graphics/mc1_rejection.png\" width=400></td>\n",
+    "        <td><img src=\"../graphics/mc1_rejection.png\" width=100%></td>\n",
     "    </tr>\n",
     "</table>"
    ]
@@ -426,7 +430,7 @@
     "\n",
     "<table>\n",
     "    <tr>\n",
-    "        <td><img src=\"../graphics/mc1_sandbox_ab.png\" width=500></td>\n",
+    "        <td><img src=\"../graphics/mc1_sandbox_ab.png\" width=100%></td>\n",
     "    </tr>\n",
     "</table>"
    ]
@@ -443,7 +447,7 @@
     "How stationary does each sequence appear?\n",
     "<table>\n",
     "    <tr>\n",
-    "        <td><img src=\"../graphics/mc1_sandbox_a.png\" width=800></td>\n",
+    "        <td><img src=\"../graphics/mc1_sandbox_a.png\" width=100%></td>\n",
     "    </tr>\n",
     "</table>"
    ]
@@ -460,7 +464,7 @@
     "\n",
     "<table>\n",
     "    <tr>\n",
-    "        <td><img src=\"../graphics/mc1_sandbox_b.png\" width=800></td>\n",
+    "        <td><img src=\"../graphics/mc1_sandbox_b.png\" width=100%></td>\n",
     "    </tr>\n",
     "</table>\n",
     "\n",
@@ -494,10 +498,12 @@
    "source": [
     "### Convergence tests - Gelman-Rubin statistic\n",
     "In detail, given chains $J=1,\\ldots,m$, each of length $n$,\n",
+    "\n",
     "* Let $B=\\frac{n}{m-1} \\sum_j \\left(\\bar{\\theta}_j - \\bar{\\theta}\\right)^2$, where $\\bar{\\theta_j}$ is the average $\\theta$ for chain $j$ and $\\bar{\\theta}$ is the global average. This is proportional to the variance of the individual-chain averages for $\\theta$.\n",
+    "\n",
     "* Let $W=\\frac{1}{m}\\sum_j s_j^2$, where $s_j^2$ is the estimated variance of $\\theta$ within chain $j$. This is the average of the individual-chain variances for $\\theta$.\n",
-    "* Let $V=\\frac{n-1}{n}W + \\frac{1}{n}B$. This is an estimate for the overall variance of $\\theta$.\n",
-    "\n"
+    "\n",
+    "* Let $V=\\frac{n-1}{n}W + \\frac{1}{n}B$. This is an estimate for the overall variance of $\\theta$."
    ]
   },
   {
@@ -509,6 +515,7 @@
    },
    "source": [
     "### Convergence tests - Gelman-Rubin statistic\n",
+    "\n",
     "Finally, $R=\\sqrt{\\frac{V}{W}}$.\n",
     "\n",
     "Note that this calculation can also be used to track convergence of combinations of parameters, or anything else derived from them."
@@ -539,7 +546,7 @@
     "Do subsequent samples look particularly independent?\n",
     "<table>\n",
     "    <tr>\n",
-    "        <td><img src=\"../graphics/mc1_sandbox_a.png\" width=800></td>\n",
+    "        <td><img src=\"../graphics/mc1_sandbox_a.png\" width=100%></td>\n",
     "    </tr>\n",
     "</table>"
    ]
@@ -573,7 +580,7 @@
     "### Correlation tests\n",
     "<table>\n",
     "    <tr>\n",
-    "        <td><img src=\"../graphics/mc1_sandbox_acf-a.png\" width=800></td>\n",
+    "        <td><img src=\"../graphics/mc1_sandbox_acf-a.png\" width=100%></td>\n",
     "    </tr>\n",
     "</table>"
    ]
@@ -589,7 +596,7 @@
     "### Correlation tests\n",
     "<table>\n",
     "    <tr>\n",
-    "        <td><img src=\"../graphics/mc1_sandbox_acf-b.png\" width=800></td>\n",
+    "        <td><img src=\"../graphics/mc1_sandbox_acf-b.png\" width=100%></td>\n",
     "    </tr>\n",
     "</table>\n",
     "\n",
@@ -629,8 +636,11 @@
     "## Bonus numerical exercise: rejection sampling\n",
     "\n",
     "Implement a rejection sampler for the example figure shown above. For this example,\n",
+    "\n",
     "* $p(x)$ is the $\\chi^2$ distribution with 3 degrees of freedom\n",
+    "\n",
     "* $A=\\pi$\n",
+    "\n",
     "* $g(x)$ is a normal distribution with mean 0 and standard deviation 5\n",
     "\n",
     "Use a different envelope function if you wish. Verify that your samples do indeed approximate the target PDF."
@@ -671,7 +681,9 @@
     "## Bonus numerical making-your-life-easier exercise: convergence\n",
     "\n",
     "Write some code to perform the Gelman-Rubin convergence test. Try it out on\n",
+    "\n",
     "1. multiple chains from the sandbox notebook. Fiddle with the sampler to get chains that do/do not display nice convergence after e.g. 5000 steps.\n",
+    "\n",
     "2. multiple \"chains\" produced from independent sampling, e.g. from the inverse-transform or rejection examples above or one of the examples in previous chunks.\n",
     "\n",
     "You'll be expected to test convergence from now on, so having a function to do so will be helpful.\n",

--- a/code/montecarlo1.py
+++ b/code/montecarlo1.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 plt.rc('text', usetex=True)
 plt.rcParams['xtick.labelsize'] = 'x-large'


### PR DESCRIPTION
@abmantz I tried the slides in `montecarlo1.ipynb` on a projector, with both HDMI and VGA. The figures looked better bigger, so I switched to `width=100%` in each case, and adopted `figsize=(15.0,8.0)` when plotting live. I also noticed that sometimes the latex looks a little garbled: this seems to improve if the Markdown bullet points are separated  by a blank line. Otherwise you just need to execute the cell again...

You can merge this PR now, and I'll re-use the same branch if I have further comments before closing #96.