### PR TITLE
github.io page update

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>PHYS366: Statistical Methods in Astrophysics</title>
+    <title>PHYSICS 366: Statistical Methods in Astrophysics</title>
 
     <link rel="stylesheet" href="stylesheets/styles.css">
     <link rel="stylesheet" href="stylesheets/github-light.css">
@@ -18,7 +18,7 @@
       <header>
         <h1 class="header">Statistical Methods in Astrophysics</h1>
         <p class="header">Course notes and resources for Stanford
-    University graduate course Physics 366: Special Topics in Astrophysics: Statistical Methods, taught by Dr. Adam Mantz and Dr. Phil Marshall </p>
+    University graduate course Physics 366: Statistical Methods in Astrophysics, taught by Dr. Adam Mantz and Dr. Phil Marshall </p>
 
         <ul>
          <li><a class="buttons github" href="https://github.com/KIPAC/StatisticalMethods">View On GitHub</a></li>
@@ -27,11 +27,11 @@
 
       </header>
       <section>
-        <h1>
-<a id="phys366-special-topics-in-astrophysics-statistical-methods" class="anchor" href="#phys366-special-topics-in-astrophysics-statistical-methods" aria-hidden="true"><span class="octicon octicon-link"></span></a>PHYS366: Special Topics in Astrophysics: Statistical Methods</h1>
+      <h1>
+<a id="phys366-special-topics-in-astrophysics-statistical-methods" class="anchor" href="#phys366-special-topics-in-astrophysics-statistical-methods" aria-hidden="true"><span class="octicon octicon-link"></span></a>PHYSICS 366: Statistical Methods in Astrophysics</h1>
 
-<h3>
-<a id="course-description" class="anchor" href="#course-description" aria-hidden="true"><span class="octicon octicon-link"></span></a>Course Description</h3>
+	<h2>
+<a id="course-description" class="anchor" href="#course-description" aria-hidden="true"><span class="octicon octicon-link"></span></a>Course Description</h2>
 
 <p>This course is intended to provide an introduction to modern
 statistical methodology and its applications to problems in
@@ -41,12 +41,12 @@ strongly encourage most first and second year students working in
 KIPAC to take the course.  Our goal is to provide a background that
 will be directly relevant to the kind of problems that typical KIPAC
 students will encounter in their research.</p>
-
-	<h3>
-<a id="course-objectives" class="anchor" href="#course-objectives" aria-hidden="true"><span class="octicon octicon-link"></span></a>Course Objectives</h3>
+	
+	<h2>
+<a id="course-objectives" class="anchor" href="#course-objectives" aria-hidden="true"><span class="octicon octicon-link"></span></a>Course Objectives</h2>
 
 	Our goal is that students taking this course will:
-<ul>
+	<ul>
   <li>develop familiarity in working with various types of astronomical data. </li>
   <li>understand the role of modeling in data analysis. </li>
   <li>develop facility with various types of inference from data. </li>
@@ -56,31 +56,34 @@ students will encounter in their research.</p>
   are likely to encounter in their research. </li>
   </ul>
 
-<h3>
-<a id="preliminaries" class="anchor" href="#preliminaries" aria-hidden="true"><span class="octicon octicon-link"></span></a>Preliminaries</h3>
+  <h2>
+<a id="information" class="anchor" href="#information" aria-hidden="true"><span class="octicon octicon-link"></span></a>Information</h2>
 
-<ul>
-<li><a href="https://github.com/KIPAC/StatisticalMethods/blob/master/doc/Stanford.md">Information for Stanford Students</a></li>
-<li><a href="https://github.com/KIPAC/StatisticalMethods/blob/master/doc/GettingStarted.md">Getting Started</a></li>
-</ul>
+  <h3>For anyone</h3>
 
-<h3>
-<a id="schedule" class="anchor" href="#schedule"
-aria-hidden="true"><span class="octicon
-octicon-link"></span></a>Course Schedule</h3>
-This is a ten-week course, running through winter
-quarter, Tuesday January 10 -- Thursday March 16, 2017.
-The course will meet Tuesdays and Thursdays from 3-4:20pm in Building 380 Room 381T.</ul>
+  <ul>
+    <li> <a href="https://github.com/KIPAC/StatisticalMethods/blob/master/doc/README.md">About this Course</a></li>
+    <li> <a href="https://github.com/KIPAC/StatisticalMethods/blob/master/doc/GettingStarted.md">Getting Started</a></li>
+  </ul>
 
-<h3>
-<a id="contact" class="anchor" href="#contact" aria-hidden="true"><span class="octicon octicon-link"></span></a>Contact</h3>
+  <h3>For Stanford students</h3>
+
+  <ul>
+    <li> <a href="https://github.com/KIPAC/StatisticalMethods/blob/master/doc/Stanford.md">Policies, Assignments, Grading, ...</a></li>
+    <li> <a href="https://github.com/KIPAC/StatisticalMethods/blob/master/doc/RulesOfEngagement.md">Class Participation Rules of Engagement</a></li>
+    <li> <a href="https://github.com/abmantz/phys366_2019">Private Repository for Submitting Assignments</a></li>
+  </ul>
+    
+
+<h2>
+<a id="contact" class="anchor" href="#contact" aria-hidden="true"><span class="octicon octicon-link"></span></a>Contact</h2>
 
 <ul>
 <li><a href="http://www.slac.stanford.edu/~amantz">Adam Mantz</a></li>
 <li><a href="http://www.slac.stanford.edu/~pjm">Phil Marshall</a></li>
 </ul>
 
-<p>All materials Copyright 2015, 2017 Adam Mantz and Phil Marshall, and distributed for copying and extension under the GPLv2 License. </p>
+<p>All materials Copyright 2015, 2017, 2019 Adam Mantz and Phil Marshall, and distributed for copying and extension under the GPLv2 License. </p>
       </section>
       <footer>
         <p><small>Hosted on <a href="https://pages.github.com">GitHub Pages</a> using the Dinky theme</small></p>


### PR DESCRIPTION
Content matches the new top-level README. All of the hyperlinks point to the master branch, so if we update now they'll be broken for a while... but we might want to go ahead and do it anyway. Or change the links to point at devel-2019 and try to remember to update them later.